### PR TITLE
highlight the first word of s-expressions

### DIFF
--- a/grammars/sexp.json
+++ b/grammars/sexp.json
@@ -37,13 +37,13 @@
       "match": "[^\"() \\t\\n\\r;]+",
       "name": "string.unquoted.sexp"
     }, {
-      "begin": "\\( *(\\w+)",
+      "begin": "(\\()\\s*(\\w*)",
       "end": "\\)",
       "captures": {
-        "0": {
+        "1": {
           "name": "keyword.operator.list.sexp"
         },
-        "1": {
+        "2": {
           "name": "entity.name.function"
 
         }

--- a/grammars/sexp.json
+++ b/grammars/sexp.json
@@ -37,11 +37,15 @@
       "match": "[^\"() \\t\\n\\r;]+",
       "name": "string.unquoted.sexp"
     }, {
-      "begin": "\\(",
+      "begin": "\\( *(\\w+)",
       "end": "\\)",
       "captures": {
         "0": {
           "name": "keyword.operator.list.sexp"
+        },
+        "1": {
+          "name": "entity.name.function"
+
         }
       },
       "name": "meta.list.sexp",


### PR DESCRIPTION
This patch colorizes the first word of S-expressions in dune files differently from the rest of the expression. Since they have a special meaning I believe this improves readability.

It may break colorization in situations when the first thing occurring after `(` is not a word but I don't think this can happen in a valid dune file. So I guess this is not really an issue?