### PR TITLE
Little fix for dune variables

### DIFF
--- a/grammars/sexp.json
+++ b/grammars/sexp.json
@@ -34,7 +34,7 @@
         "name": "constant.character.escape.sexp"
       }]
     }, {
-      "match": "[^\"() \\t\\n\\r;]+",
+      "match": "[^\"() %\\t\\n\\r;]+",
       "name": "string.unquoted.sexp"
     }, {
       "begin": "\\(",


### PR DESCRIPTION
Allows dune variables that are not preceded by a space to be correctly matched. For instance, the `OCAML:%{ocaml_version}` bit in the following example:

```
(...
 (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
```